### PR TITLE
Limit OpenCV_LIBS to opencv_world when BUILD_opencv_world=ON

### DIFF
--- a/cmake/templates/OpenCVConfig.cmake.in
+++ b/cmake/templates/OpenCVConfig.cmake.in
@@ -334,6 +334,10 @@ foreach(__opttype OPT DBG)
   endif()
 endforeach()
 
+if(TARGET opencv_world)
+  set(OpenCV_LIBS opencv_world)
+endif()
+
 # ==============================================================
 # Compatibility stuff
 # ==============================================================


### PR DESCRIPTION
... since the other libs are not installed and linking with ${OpenCV_LIBS} in the calling CMakeLists.txt fails.  
