### PR TITLE
manage ffmpeg w/ hunter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,8 +128,8 @@ endif()
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.19.68.tar.gz"
-    SHA1 "ad0d042d8ec56a3c6a4bda1e657f1f65b494ab12"
+    URL "https://github.com/ruslo/hunter/archive/v0.23.158.tar.gz"
+    SHA1 "4f3d8287a546091d1968ee80e02f121b312fceea"
 )
 
 project(OpenCV CXX C)

--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2015, Ruslan Baratov
+# Copyright (c) 2013-2019, Ruslan Baratov
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -25,7 +25,7 @@
 # This is a gate file to Hunter package manager.
 # Include this file using `include` command and add package you need, example:
 #
-#     cmake_minimum_required(VERSION 3.0)
+#     cmake_minimum_required(VERSION 3.2)
 #
 #     include("cmake/HunterGate.cmake")
 #     HunterGate(
@@ -42,35 +42,46 @@
 #     * https://github.com/hunter-packages/gate/
 #     * https://github.com/ruslo/hunter
 
-cmake_minimum_required(VERSION 3.0) # Minimum for Hunter
+option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
+
+if(HUNTER_ENABLED)
+  if(CMAKE_VERSION VERSION_LESS "3.2")
+    message(
+        FATAL_ERROR
+        "At least CMake version 3.2 required for Hunter dependency management."
+        " Update CMake or set HUNTER_ENABLED to OFF."
+    )
+  endif()
+endif()
+
 include(CMakeParseArguments) # cmake_parse_arguments
 
-option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
 option(HUNTER_STATUS_PRINT "Print working status" ON)
 option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
+option(HUNTER_TLS_VERIFY "Enable/disable TLS certificate checking on downloads" ON)
 
-set(HUNTER_WIKI "https://github.com/ruslo/hunter/wiki")
+set(HUNTER_ERROR_PAGE "https://docs.hunter.sh/en/latest/reference/errors")
 
 function(hunter_gate_status_print)
-  foreach(print_message ${ARGV})
-    if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+  if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+    foreach(print_message ${ARGV})
       message(STATUS "[hunter] ${print_message}")
-    endif()
-  endforeach()
+    endforeach()
+  endif()
 endfunction()
 
 function(hunter_gate_status_debug)
-  foreach(print_message ${ARGV})
-    if(HUNTER_STATUS_DEBUG)
+  if(HUNTER_STATUS_DEBUG)
+    foreach(print_message ${ARGV})
       string(TIMESTAMP timestamp)
       message(STATUS "[hunter *** DEBUG *** ${timestamp}] ${print_message}")
-    endif()
-  endforeach()
+    endforeach()
+  endif()
 endfunction()
 
-function(hunter_gate_wiki wiki_page)
-  message("------------------------------ WIKI -------------------------------")
-  message("    ${HUNTER_WIKI}/${wiki_page}")
+function(hunter_gate_error_page error_page)
+  message("------------------------------ ERROR ------------------------------")
+  message("    ${HUNTER_ERROR_PAGE}/${error_page}.html")
   message("-------------------------------------------------------------------")
   message("")
   message(FATAL_ERROR "")
@@ -83,14 +94,13 @@ function(hunter_gate_internal_error)
   endforeach()
   message("[hunter ** INTERNAL **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
   message("")
-  hunter_gate_wiki("error.internal")
+  hunter_gate_error_page("error.internal")
 endfunction()
 
 function(hunter_gate_fatal_error)
-  cmake_parse_arguments(hunter "" "WIKI" "" "${ARGV}")
-  string(COMPARE EQUAL "${hunter_WIKI}" "" have_no_wiki)
-  if(have_no_wiki)
-    hunter_gate_internal_error("Expected wiki")
+  cmake_parse_arguments(hunter "" "ERROR_PAGE" "" "${ARGV}")
+  if("${hunter_ERROR_PAGE}" STREQUAL "")
+    hunter_gate_internal_error("Expected ERROR_PAGE")
   endif()
   message("")
   foreach(x ${hunter_UNPARSED_ARGUMENTS})
@@ -98,11 +108,11 @@ function(hunter_gate_fatal_error)
   endforeach()
   message("[hunter ** FATAL ERROR **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
   message("")
-  hunter_gate_wiki("${hunter_WIKI}")
+  hunter_gate_error_page("${hunter_ERROR_PAGE}")
 endfunction()
 
 function(hunter_gate_user_error)
-  hunter_gate_fatal_error(${ARGV} WIKI "error.incorrect.input.data")
+  hunter_gate_fatal_error(${ARGV} ERROR_PAGE "error.incorrect.input.data")
 endfunction()
 
 function(hunter_gate_self root version sha1 result)
@@ -123,14 +133,10 @@ function(hunter_gate_self root version sha1 result)
 
   string(SUBSTRING "${sha1}" 0 7 archive_id)
 
-  if(EXISTS "${root}/cmake/Hunter")
-    set(hunter_self "${root}")
-  else()
-    set(
-        hunter_self
-        "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
-    )
-  endif()
+  set(
+      hunter_self
+      "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
+  )
 
   set("${result}" "${hunter_self}" PARENT_SCOPE)
 endfunction()
@@ -184,23 +190,9 @@ function(hunter_gate_detect_root)
 
   hunter_gate_fatal_error(
       "Can't detect HUNTER_ROOT"
-      WIKI "error.detect.hunter.root"
+      ERROR_PAGE "error.detect.hunter.root"
   )
 endfunction()
-
-macro(hunter_gate_lock dir)
-  if(NOT HUNTER_SKIP_LOCK)
-    if("${CMAKE_VERSION}" VERSION_LESS "3.2")
-      hunter_gate_fatal_error(
-          "Can't lock, upgrade to CMake 3.2 or use HUNTER_SKIP_LOCK"
-          WIKI "error.can.not.lock"
-      )
-    endif()
-    hunter_gate_status_debug("Locking directory: ${dir}")
-    file(LOCK "${dir}" DIRECTORY GUARD FUNCTION)
-    hunter_gate_status_debug("Lock done")
-  endif()
-endmacro()
 
 function(hunter_gate_download dir)
   string(
@@ -217,7 +209,7 @@ function(hunter_gate_download dir)
         "Settings:"
         "  HUNTER_ROOT: ${HUNTER_GATE_ROOT}"
         "  HUNTER_SHA1: ${HUNTER_GATE_SHA1}"
-        WIKI "error.run.install"
+        ERROR_PAGE "error.run.install"
     )
   endif()
   string(COMPARE EQUAL "${dir}" "" is_bad)
@@ -241,7 +233,10 @@ function(hunter_gate_download dir)
   set(build_dir "${dir}/Build")
   set(cmakelists "${dir}/CMakeLists.txt")
 
-  hunter_gate_lock("${dir}")
+  hunter_gate_status_debug("Locking directory: ${dir}")
+  file(LOCK "${dir}" DIRECTORY GUARD FUNCTION)
+  hunter_gate_status_debug("Lock done")
+
   if(EXISTS "${done_location}")
     # while waiting for lock other instance can do all the job
     hunter_gate_status_debug("File '${done_location}' found, skip install")
@@ -258,7 +253,7 @@ function(hunter_gate_download dir)
   file(
       WRITE
       "${cmakelists}"
-      "cmake_minimum_required(VERSION 3.0)\n"
+      "cmake_minimum_required(VERSION 3.2)\n"
       "project(HunterDownload LANGUAGES NONE)\n"
       "include(ExternalProject)\n"
       "ExternalProject_Add(\n"
@@ -269,6 +264,8 @@ function(hunter_gate_download dir)
       "    SHA1=${HUNTER_GATE_SHA1}\n"
       "    DOWNLOAD_DIR\n"
       "    \"${dir}\"\n"
+      "    TLS_VERIFY\n"
+      "    ${HUNTER_TLS_VERIFY}\n"
       "    SOURCE_DIR\n"
       "    \"${dir}/Unpacked\"\n"
       "    CONFIGURE_COMMAND\n"
@@ -287,15 +284,45 @@ function(hunter_gate_download dir)
   endif()
 
   hunter_gate_status_debug("Run generate")
+
+  # Need to add toolchain file too.
+  # Otherwise on Visual Studio + MDD this will fail with error:
+  # "Could not find an appropriate version of the Windows 10 SDK installed on this machine"
+  if(EXISTS "${CMAKE_TOOLCHAIN_FILE}")
+    get_filename_component(absolute_CMAKE_TOOLCHAIN_FILE "${CMAKE_TOOLCHAIN_FILE}" ABSOLUTE)
+    set(toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=${absolute_CMAKE_TOOLCHAIN_FILE}")
+  else()
+    # 'toolchain_arg' can't be empty
+    set(toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=")
+  endif()
+
+  string(COMPARE EQUAL "${CMAKE_MAKE_PROGRAM}" "" no_make)
+  if(no_make)
+    set(make_arg "")
+  else()
+    # Test case: remove Ninja from PATH but set it via CMAKE_MAKE_PROGRAM
+    set(make_arg "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}")
+  endif()
+
   execute_process(
-      COMMAND "${CMAKE_COMMAND}" "-H${dir}" "-B${build_dir}"
+      COMMAND
+      "${CMAKE_COMMAND}"
+      "-H${dir}"
+      "-B${build_dir}"
+      "-G${CMAKE_GENERATOR}"
+      "${toolchain_arg}"
+      ${make_arg}
       WORKING_DIRECTORY "${dir}"
       RESULT_VARIABLE download_result
       ${logging_params}
   )
 
   if(NOT download_result EQUAL 0)
-    hunter_gate_internal_error("Configure project failed")
+    hunter_gate_internal_error(
+        "Configure project failed."
+        "To reproduce the error run: ${CMAKE_COMMAND} -H${dir} -B${build_dir} -G${CMAKE_GENERATOR} ${toolchain_arg} ${make_arg}"
+        "In directory ${dir}"
+    )
   endif()
 
   hunter_gate_status_print(
@@ -340,6 +367,17 @@ macro(HunterGate)
     # Empty function to avoid error "unknown function"
     function(hunter_add_package)
     endfunction()
+
+    set(
+        _hunter_gate_disabled_mode_dir
+        "${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/disabled-mode"
+    )
+    if(EXISTS "${_hunter_gate_disabled_mode_dir}")
+      hunter_gate_status_debug(
+          "Adding \"disabled-mode\" modules: ${_hunter_gate_disabled_mode_dir}"
+      )
+      list(APPEND CMAKE_PREFIX_PATH "${_hunter_gate_disabled_mode_dir}")
+    endif()
   elseif(_hunter_gate_done)
     hunter_gate_status_debug("Secondary HunterGate (use old settings)")
     hunter_gate_self(
@@ -350,14 +388,14 @@ macro(HunterGate)
     )
     include("${_hunter_self}/cmake/Hunter")
   else()
-    set(HUNTER_GATE_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
+    set(HUNTER_GATE_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}")
 
     string(COMPARE NOTEQUAL "${PROJECT_NAME}" "" _have_project_name)
     if(_have_project_name)
       hunter_gate_fatal_error(
           "Please set HunterGate *before* 'project' command. "
           "Detected project: ${PROJECT_NAME}"
-          WIKI "error.huntergate.before.project"
+          ERROR_PAGE "error.huntergate.before.project"
       )
     endif()
 
@@ -377,16 +415,16 @@ macro(HunterGate)
     string(COMPARE NOTEQUAL "${HUNTER_GATE_GLOBAL}" "" _have_global)
     string(COMPARE NOTEQUAL "${HUNTER_GATE_FILEPATH}" "" _have_filepath)
 
+    if(_have_unparsed)
+      hunter_gate_user_error(
+          "HunterGate unparsed arguments: ${HUNTER_GATE_UNPARSED_ARGUMENTS}"
+      )
+    endif()
     if(_empty_sha1)
       hunter_gate_user_error("SHA1 suboption of HunterGate is mandatory")
     endif()
     if(_empty_url)
       hunter_gate_user_error("URL suboption of HunterGate is mandatory")
-    endif()
-    if(_have_unparsed)
-      hunter_gate_user_error(
-          "HunterGate unparsed arguments: ${HUNTER_GATE_UNPARSED_ARGUMENTS}"
-      )
     endif()
     if(_have_global)
       if(HUNTER_GATE_LOCAL)
@@ -427,7 +465,7 @@ macro(HunterGate)
             "HUNTER_ROOT (${HUNTER_GATE_ROOT}) contains spaces."
             "Set HUNTER_ALLOW_SPACES_IN_PATH=ON to skip this error"
             "(Use at your own risk!)"
-            WIKI "error.spaces.in.hunter.root"
+            ERROR_PAGE "error.spaces.in.hunter.root"
         )
       endif()
     endif()
@@ -448,48 +486,41 @@ macro(HunterGate)
         "${HUNTER_GATE_ROOT}"
         "${HUNTER_GATE_VERSION}"
         "${HUNTER_GATE_SHA1}"
-        hunter_self_
+        _hunter_self
     )
 
-    set(_master_location "${hunter_self_}/cmake/Hunter")
-    if(EXISTS "${HUNTER_GATE_ROOT}/cmake/Hunter")
-      # Hunter downloaded manually (e.g. by 'git clone')
-      set(_unused "xxxxxxxxxx")
-      set(HUNTER_GATE_SHA1 "${_unused}")
-      set(HUNTER_GATE_VERSION "${_unused}")
-    else()
-      get_filename_component(_archive_id_location "${hunter_self_}/.." ABSOLUTE)
-      set(_done_location "${_archive_id_location}/DONE")
-      set(_sha1_location "${_archive_id_location}/SHA1")
+    set(_master_location "${_hunter_self}/cmake/Hunter")
+    get_filename_component(_archive_id_location "${_hunter_self}/.." ABSOLUTE)
+    set(_done_location "${_archive_id_location}/DONE")
+    set(_sha1_location "${_archive_id_location}/SHA1")
 
-      # Check Hunter already downloaded by HunterGate
-      if(NOT EXISTS "${_done_location}")
-        hunter_gate_download("${_archive_id_location}")
-      endif()
+    # Check Hunter already downloaded by HunterGate
+    if(NOT EXISTS "${_done_location}")
+      hunter_gate_download("${_archive_id_location}")
+    endif()
 
-      if(NOT EXISTS "${_done_location}")
-        hunter_gate_internal_error("hunter_gate_download failed")
-      endif()
+    if(NOT EXISTS "${_done_location}")
+      hunter_gate_internal_error("hunter_gate_download failed")
+    endif()
 
-      if(NOT EXISTS "${_sha1_location}")
-        hunter_gate_internal_error("${_sha1_location} not found")
-      endif()
-      file(READ "${_sha1_location}" _sha1_value)
-      string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
-      if(NOT _is_equal)
-        hunter_gate_internal_error(
-            "Short SHA1 collision:"
-            "  ${_sha1_value} (from ${_sha1_location})"
-            "  ${HUNTER_GATE_SHA1} (HunterGate)"
-        )
-      endif()
-      if(NOT EXISTS "${_master_location}")
-        hunter_gate_user_error(
-            "Master file not found:"
-            "  ${_master_location}"
-            "try to update Hunter/HunterGate"
-        )
-      endif()
+    if(NOT EXISTS "${_sha1_location}")
+      hunter_gate_internal_error("${_sha1_location} not found")
+    endif()
+    file(READ "${_sha1_location}" _sha1_value)
+    string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
+    if(NOT _is_equal)
+      hunter_gate_internal_error(
+          "Short SHA1 collision:"
+          "  ${_sha1_value} (from ${_sha1_location})"
+          "  ${HUNTER_GATE_SHA1} (HunterGate)"
+      )
+    endif()
+    if(NOT EXISTS "${_master_location}")
+      hunter_gate_user_error(
+          "Master file not found:"
+          "  ${_master_location}"
+          "try to update Hunter/HunterGate"
+      )
     endif()
     include("${_master_location}")
     set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)


### PR DESCRIPTION
This adds support for ffmpeg as a hunter package w/ appropriate options: `-DWITH_FFMPEG=ON -DOPENCV_FFMPEG_USE_FIND_PACKAGE=ON`

* update Hunter release
* update HunterGate
* enable ffmpeg package w/ `if(HUNTER_ENABLED)` 
* translate ffmpeg CONFIG libs to CMake's variable style usage, i.e. `${FFMPEG_INCLUDE_DIRS}, ${FFMPEG_LIBRARIES}`


